### PR TITLE
Enable Java 17 support for Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
Thank you for maintaining this library - I find it very helpful!

I noticed you had updated it to use the new Android 14 compatible Play Services in version 2.1.3, but the build was failing on Jitpack (see https://jitpack.io/com/github/numerative/Five-Star-Me/2.1.3/build.log), so the package is unavailable. The Gradle build for 2.1.3 is failing because Jitpack by default compiles with OpenJDK 8 (see https://jitpack.io/docs/BUILDING/#java-version).

This PR configures Jitpack to use OpenJDK 17, which is required by Gradle 8.

I have tested this PR on Jitpack with success (see https://jitpack.io/com/github/pmachapman/Five-Star-Me/fix~jitpack-37ccf1af2b-1/build.log).